### PR TITLE
Support for Pimcore 6.3 and above

### DIFF
--- a/src/AdvancedSearchBundle/Resources/public/js/pimcore/searchConfig/resultPanel.js
+++ b/src/AdvancedSearchBundle/Resources/public/js/pimcore/searchConfig/resultPanel.js
@@ -589,4 +589,8 @@ pimcore.bundle.advancedSearch.searchConfig.resultPanel = Class.create(pimcore.ob
 
 });
 
-pimcore.bundle.advancedSearch.searchConfig.resultPanel.addMethods(pimcore.object.helpers.gridcolumnconfig);
+if (pimcore.object.helpers.gridcolumnconfig) {
+    pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel.addMethods(pimcore.object.helpers.gridcolumnconfig);
+} else {
+    pimcore.bundle.advancedObjectSearch.searchConfig.resultPanel.addMethods(pimcore.element.helpers.gridColumnConfig);
+}


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? |  no
| Tests pass?   | yes

Support for Pimcore 6.3 and newer version where `pimcore.object.helpers.gridcolumnconfig` was removed.
