### PR TITLE
Fix/url length and sorting

### DIFF
--- a/src/AdvancedSearchBundle/Controller/AdminController.php
+++ b/src/AdvancedSearchBundle/Controller/AdminController.php
@@ -145,6 +145,19 @@ class AdminController extends \Pimcore\Bundle\AdminBundle\Controller\AdminContro
 
                 $sortBy = $sort->property;
                 $sortDirection = $sort->direction;
+
+                $colMappings = [
+                    'key' => 'o_key',
+                    'fullpath' => ['o_path', 'o_key'],
+                    'id' => 'o_id',
+                    'published' => 'o_published',
+                    'modificationDate' => 'o_modificationDate',
+                    'creationDate' => 'o_creationDate'
+                ];
+
+                if (array_key_exists($sortBy, $colMappings)) {
+                    $sortBy = $colMappings[$sortBy];
+                }
             }
 
             $listClass = '\\Pimcore\\Model\\DataObject\\' . ucfirst($className) . '\\Listing';

--- a/src/AdvancedSearchBundle/Resources/public/js/pimcore/searchConfig/resultPanel.js
+++ b/src/AdvancedSearchBundle/Resources/public/js/pimcore/searchConfig/resultPanel.js
@@ -181,6 +181,7 @@ pimcore.bundle.advancedSearch.searchConfig.resultPanel = Class.create(pimcore.ob
 
         this.store = gridHelper.getStore(this.noBatchColumns, this.batchAppendColumns);
         this.store.setPageSize(itemsPerPage);
+        this.store.proxy.actionMethods.read = 'POST';
 
 
         var gridColumns = gridHelper.getGridColumns();


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no

Solution to this problem: 
414 Request-URI Too Large - all attributes are send to the server even if they aren’t set, which causes url to be longer than 8KB. 
    
## Changes
### Changed
- parameters send in POST instead of GET
### Fixed
- results can be sorted by system fields (previously caused error 500)

