### PR TITLE
Mark selected grid on grid select

### DIFF
--- a/src/AdvancedSearchBundle/Resources/public/js/pimcore/searchConfig/resultPanel.js
+++ b/src/AdvancedSearchBundle/Resources/public/js/pimcore/searchConfig/resultPanel.js
@@ -172,7 +172,7 @@ pimcore.bundle.advancedSearch.searchConfig.resultPanel = Class.create(pimcore.ob
             fields = response;
             this.settings = settings;
             if (this.columnConfigButton) {
-                this.buildColumnConfigMenu(true);
+                this.buildColumnConfigMenu();
             }
         }
 
@@ -246,7 +246,7 @@ pimcore.bundle.advancedSearch.searchConfig.resultPanel = Class.create(pimcore.ob
             menu: []
         });
 
-        this.buildColumnConfigMenu(true);
+        this.buildColumnConfigMenu();
 
         var tbars = [];
         var plugins = [];


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #...

    
## Changes
### Changed
- ...
### Added
- ...
### Removed
- ...
### Fixed
- When grid is selected then it will be marked as selected in the grid select dropdown

